### PR TITLE
Fix compilation warning/error in ImprovWiFiLibrary.cpp

### DIFF
--- a/src/ImprovWiFiLibrary.cpp
+++ b/src/ImprovWiFiLibrary.cpp
@@ -209,7 +209,7 @@ void ImprovWiFi::getAvailableWifiNetworks()
   {
     std::vector<std::string> wifinetworks = {
         WiFi.SSID(id).c_str(),
-        std::string{WiFi.RSSI(id)},
+        std::to_string(WiFi.RSSI(id)),
         (WiFi.encryptionType(id) == WIFI_AUTH_OPEN ? "NO" : "YES")
     };
 


### PR DESCRIPTION
This commit fixes a compilation warning (treated as an error in `esp-idf`):

```
clockwise/components/Improv-WiFi-Library/src/ImprovWiFiLibrary.cpp: In member function 'void ImprovWiFi::getAvailableWifiNetworks()':
clockwise/components/Improv-WiFi-Library/src/ImprovWiFiLibrary.cpp:212:30: error: narrowing conversion of '((WiFiScanClass*)(& WiFi))->WiFiScanClass::RSSI(((int)((uint8_t)id)))' from 'int32_t' {aka 'int'} to 'char' inside { } [-Werror=narrowing]
```

I'm trying to fix https://github.com/jnthas/clockwise/issues/16 and this warning/error is preventing the project from compiling.