### PR TITLE
Create `Improv-WiFi-Library` component for ESP-IDF.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.5)
+
+idf_component_register(
+                       SRCS "src/ImprovWiFiLibrary.cpp"
+                       INCLUDE_DIRS src
+                       PRIV_REQUIRES arduino
+)
+
+project(Improv-WiFi-Library)


### PR DESCRIPTION
This file turns the library into a component that can be used by ESP-IDF.

This is one of the steps required to fix https://github.com/jnthas/clockwise/issues/16